### PR TITLE
Users can create building entry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,11 @@
       "name": "roommate-organizer",
       "version": "0.1.0",
       "dependencies": {
-        "@prisma/client": "^5.9.1",
+        "@prisma/client": "^5.10.1",
         "@supabase/auth-helpers-nextjs": "^0.9.0",
         "@supabase/supabase-js": "^2.39.3",
         "dotenv": "^16.4.1",
-        "next": "14.1.0",
+        "next": "^14.1.0",
         "postgres": "^3.4.3",
         "prisma": "^5.9.1",
         "react": "^18",
@@ -373,9 +373,9 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.9.1.tgz",
-      "integrity": "sha512-caSOnG4kxcSkhqC/2ShV7rEoWwd3XrftokxJqOCMVvia4NYV/TPtJlS9C2os3Igxw/Qyxumj9GBQzcStzECvtQ==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.10.1.tgz",
+      "integrity": "sha512-4R8Vp6sSwVJSnOxw8WU1WSLqE/G3WJy1xA05XvW87cINoB1hEY7endw5Ppy6TrIBCCtHQim2lqfHkbPvv+i7bQ==",
       "hasInstallScript": true,
       "engines": {
         "node": ">=16.13"

--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@prisma/client": "^5.9.1",
+    "@prisma/client": "^5.10.1",
     "@supabase/auth-helpers-nextjs": "^0.9.0",
     "@supabase/supabase-js": "^2.39.3",
     "dotenv": "^16.4.1",
-    "next": "14.1.0",
+    "next": "^14.1.0",
     "postgres": "^3.4.3",
     "prisma": "^5.9.1",
     "react": "^18",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,13 +20,13 @@ model Profile {
   updatedAt                 DateTime           @default(now()) @updatedAt
   deletedAt                 DateTime?
   userId                    String?            @unique
-  rooms                     Room[]             @relation("RoomMembers")
   announcements             Announcement[]
-  createdChoreListItems     ChoreListItem[]    @relation("CreatedChoreListItems")
-  createdShoppingListItems  ShoppingListItem[] @relation("CreatedShoppingListItems")
-  assignedChoreListItems    ChoreListItem[]    @relation("AssignedChoreListItems")
-  assignedShoppingListItems ShoppingListItem[] @relation("AssignedShoppingListItems")
   buildings                 Building[]
+  assignedChoreListItems    ChoreListItem[]    @relation("AssignedChoreListItems")
+  createdChoreListItems     ChoreListItem[]    @relation("CreatedChoreListItems")
+  assignedShoppingListItems ShoppingListItem[] @relation("AssignedShoppingListItems")
+  createdShoppingListItems  ShoppingListItem[] @relation("CreatedShoppingListItems")
+  rooms                     Room[]             @relation("RoomMembers")
 
   @@map("profile")
   @@schema("public")
@@ -53,11 +53,11 @@ model Room {
   updatedAt     DateTime       @default(now()) @updatedAt
   deletedAt     DateTime?
   buildingId    String?
-  building      Building?      @relation(fields: [buildingId], references: [id])
-  members       Profile[]      @relation("RoomMembers")
-  shoppingLists ShoppingList[]
-  choreLists    ChoreList[]
   announcements Announcement[]
+  choreLists    ChoreList[]
+  building      Building?      @relation(fields: [buildingId], references: [id])
+  shoppingLists ShoppingList[]
+  members       Profile[]      @relation("RoomMembers")
 
   @@map("room")
   @@schema("public")
@@ -86,10 +86,10 @@ model ChoreListItem {
   updatedAt    DateTime  @default(now()) @updatedAt
   deletedAt    DateTime?
   choreListId  String
-  choreList    ChoreList @relation(fields: [choreListId], references: [id])
   assignedToId String?
-  assignedTo   Profile?  @relation("AssignedChoreListItems", fields: [assignedToId], references: [id])
   createdById  String?
+  assignedTo   Profile?  @relation("AssignedChoreListItems", fields: [assignedToId], references: [id])
+  choreList    ChoreList @relation(fields: [choreListId], references: [id])
   createdBy    Profile?  @relation("CreatedChoreListItems", fields: [createdById], references: [id])
 
   @@map("chore_list_item")
@@ -120,11 +120,11 @@ model ShoppingListItem {
   updatedAt      DateTime     @default(now()) @updatedAt
   deletedAt      DateTime?
   shoppingListId String
-  shoppingList   ShoppingList @relation(fields: [shoppingListId], references: [id])
   assignedToId   String?
-  assignedTo     Profile?     @relation("AssignedShoppingListItems", fields: [assignedToId], references: [id])
   createdById    String?
+  assignedTo     Profile?     @relation("AssignedShoppingListItems", fields: [assignedToId], references: [id])
   createdBy      Profile?     @relation("CreatedShoppingListItems", fields: [createdById], references: [id])
+  shoppingList   ShoppingList @relation(fields: [shoppingListId], references: [id])
 
   @@map("shopping_list_item")
   @@schema("public")
@@ -139,8 +139,8 @@ model Announcement {
   updatedAt DateTime  @default(now()) @updatedAt
   deletedAt DateTime?
   roomId    String
-  room      Room      @relation(fields: [roomId], references: [id])
   sentById  String
+  room      Room      @relation(fields: [roomId], references: [id])
   sentBy    Profile   @relation(fields: [sentById], references: [id])
 
   @@map("announcement")

--- a/src/app/_components/createBuilding.js
+++ b/src/app/_components/createBuilding.js
@@ -19,7 +19,12 @@ export default function AddBuildingForm({ context }) {
 
   const handleSubmit = async (event) => {
     event.preventDefault();
+    if (!context.user || !context.user.id) {
+      console.error("User ID is missing");
+      return;
+    }
     await fetch(`/api/building`, {
+      method: "POST",
       headers: {
         "Content-Type": "application/json",
       },

--- a/src/app/_components/createBuilding.js
+++ b/src/app/_components/createBuilding.js
@@ -1,0 +1,54 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+export default function AddBuildingForm({ context }) {
+  const router = useRouter();
+
+  const [buildingName, setBuildingName] = useState("");
+  const [address, setAddress] = useState("");
+
+  const handleInputBuildingName = (event) => {
+    setBuildingName(event.target.value);
+  };
+
+  const handleInputAddress = (event) => {
+    setAddress(event.target.value);
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    await fetch(`/api/building`, {
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        buildingOwnerId: context.user.id,
+        name: buildingName,
+        address: address,
+      }),
+    });
+    router.refresh(); 
+    setBuildingName("");
+    setAddress("");
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input
+        type="text"
+        placeholder="Enter building name"
+        value={buildingName}
+        onChange={handleInputBuildingName}
+      />
+      <input
+        type="text"
+        placeholder="Enter address"
+        value={address}
+        onChange={handleInputAddress}
+      />
+      <button type="submit">Add Building</button>
+    </form>
+  );
+}

--- a/src/app/api/building/route.js
+++ b/src/app/api/building/route.js
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { v4 as uuidv4 } from "uuid";
+import prisma from "../../../../lib/db";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(request, context) {
+
+
+  const buidingData = await request.json();
+  const createBuiding = await prisma.Buiding.create({
+    data: {
+      id: uuidv4(),
+      BuidingOwnerId: buidingData.BuidingOwnerId,
+      name: buidingData.name,
+      address:buidingData.address,
+     
+    },
+  });
+
+  return NextResponse.json(
+    { message: "Created buiding entry", building: buidingData },
+    { status: 200 }
+  );
+}
+

--- a/src/app/building/page.js
+++ b/src/app/building/page.js
@@ -4,17 +4,18 @@ import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
-export default async function LoginPage() {
+export default async function BuildingPage() {
   const supabase = createServerComponentClient({ cookies });
   const { data } = await supabase.auth.getSession();
   if (!data.session?.user) {
     redirect("/login");
   }
+  console.log(data.session.user)
 
   return (
     <main className="max-w-lg m-auto">
       <h1 className="text-2xl text-center mb-6">Building Details</h1>
-      <AddBuildingForm/>
+      <AddBuildingForm context={data.session}/>
     </main>
   );
 }

--- a/src/app/building/page.js
+++ b/src/app/building/page.js
@@ -1,4 +1,5 @@
 import AddBuildingForm from "@/app/_components/createBuilding";
+
 import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
@@ -6,8 +7,8 @@ import { redirect } from "next/navigation";
 export default async function LoginPage() {
   const supabase = createServerComponentClient({ cookies });
   const { data } = await supabase.auth.getSession();
-  if (data.session?.user) {
-    redirect("/");
+  if (!data.session?.user) {
+    redirect("/login");
   }
 
   return (

--- a/src/app/building/page.js
+++ b/src/app/building/page.js
@@ -1,0 +1,19 @@
+import AddBuildingForm from "@/app/_components/createBuilding";
+import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
+export default async function LoginPage() {
+  const supabase = createServerComponentClient({ cookies });
+  const { data } = await supabase.auth.getSession();
+  if (data.session?.user) {
+    redirect("/");
+  }
+
+  return (
+    <main className="max-w-lg m-auto">
+      <h1 className="text-2xl text-center mb-6">Building Details</h1>
+      <AddBuildingForm/>
+    </main>
+  );
+}


### PR DESCRIPTION
The associated Kanban board ticket is [here](https://www.notion.so/bathientran/Implement-a-section-in-the-app-for-building-management-to-post-announcements-2668d296fbdd40fa98c517e25647dab8?pvs=4)

In this PR the main feature is that users can create a new building entry.
When a building entry is created we execute the following:

- We add a building name
- We add a building address.

I also added a building directory that will be the building UI to deal with building management.

Next steps: 
- Link the building with the announcement models.
- Build an announcements component and routing.
- Create announcement model routing and page.