### PR TITLE
Add/remove room members

### DIFF
--- a/src/app/_components/RoomDetail.js
+++ b/src/app/_components/RoomDetail.js
@@ -8,6 +8,7 @@ export default function RoomDetail({ roomId }) {
   const [choreListItems, setChoreListItems] = useState([]);
   const [shoppingListItems, setShoppingListItems] = useState([]);
   const [announcementsList, setAnnouncements] = useState([]);
+  const [members, setMembers] = useState([]);
   const [roomDetails, setRoomDetails] = useState({});
 
   useEffect(() => {
@@ -15,6 +16,16 @@ export default function RoomDetail({ roomId }) {
       .then((res) => res.json())
       .then((data) => {
         setChoreListItems(data.choreListItems);
+      });
+  }, [roomId]);
+
+  useEffect(() => {
+    fetch(`/api/rooms?roomId=${roomId}`)
+      .then((res) => res.json())
+      .then((data) => {
+        console.log("HI", data)
+        setRoomDetails(data);
+        setMembers(data.members)
       });
   }, [roomId]);
 
@@ -37,11 +48,11 @@ export default function RoomDetail({ roomId }) {
       </ul>
 
       <h1>Members</h1>
-      {/* <ul>
-        {roomDetails.members.map((member, index) => (
+      <ul>
+        {members.map((member, index) => (
           <li key={index}>{member.userId}</li>
         ))}
-      </ul> */}
+      </ul>
     </div>
   );
 }

--- a/src/app/api/rooms/[slug]/route.js
+++ b/src/app/api/rooms/[slug]/route.js
@@ -1,0 +1,169 @@
+import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+import prisma from "../../../../../lib/db";
+import { checkMembership } from "../../_utils";
+
+export const dynamic = "force-dynamic";
+
+/** 
+ * @swagger
+ * /api/rooms/[slug]:
+ *   post:
+ *     summary: Add user to existing room
+ *     description: Add another user to an existing room
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               roomId:
+ *                 type: string
+ *                 description: The ID of the room
+ *               profileId:
+ *                 type: string
+ *                 description: The ID of the profile to add
+ *     responses:
+ *       200:
+ *         description: Successful response
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *       400:
+ *         description: Bad Request
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: Internal Server Error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *
+ * components:
+ *  schemas:
+ *    Room:
+ *      type: object
+ *      properties:
+ *        id:
+ *          type: string
+ *        name:
+ *          type: string
+ *        metadata:
+ *          type: object
+ *        createdAt:
+ *          type: string
+ *        updatedAt:
+ *          type: string
+ *        deletedAt:
+ *          type: string
+ *        buildingId:
+ *          type: string
+ *        members:
+ *          type: array
+ *          items:
+ *            $ref: '#/components/schemas/RoomMember'
+ *    RoomMember:
+ *      type: object
+ *      properties:
+ *        id:
+ *          type: string
+ *        role:
+ *          type: string
+ *        firstName:
+ *          type: string
+ *        lastName:
+ *          type: string
+ *        metadata:
+ *          type: object
+ *        profileImage:
+ *          type: string
+ *        createdAt:
+ *          type: string
+ *        updatedAt:
+ *          type: string
+ *        deletedAt:
+ *          type: string
+ *        userId:
+ *          type: string
+ *    Error:
+ *      type: object
+ *      properties:
+ *         message:
+ *           type: string
+ */
+
+
+
+export async function POST(request, context) {
+    try {
+      const { roomId, profileId } = await request.json();
+  
+      if (!roomId || !profileId) {
+        return NextResponse.json(
+          { message: "Both roomId and userId are required" },
+          { status: 400 }
+        );
+      }
+
+      const supabase = createServerComponentClient({ cookies });
+      const { data: user, error } = await supabase.auth.getUser();
+
+      if (error) {
+        return NextResponse.json({ message: "Unauthorized" }, { status: 400 });
+      }
+
+      await checkMembership(roomId, user.id);
+  
+      const roomExists = await prisma.room.findUnique({
+        where: { id: roomId },
+      });
+  
+      if (!roomExists) {
+        return NextResponse.json(
+          { message: "Room not found" },
+          { status: 400 }
+        );
+      }
+  
+      const profileExists = await prisma.profile.findUnique({
+        where: { id: profileId },
+      });
+  
+      if (!profileExists) {
+        return NextResponse.json(
+          { message: "Profile not found" },
+          { status: 400 }
+        );
+      }
+  
+      await prisma.room.update({
+        where: { id: roomId },
+        data: {
+          members: {
+            connect: { id: profileId },
+          },
+        },
+      });
+
+      
+  
+      return NextResponse.json(
+        { message: "User added to the room successfully" },
+        { status: 200 }
+      );
+    } catch (error) {
+      console.error("Error adding user to room:", error);
+      return NextResponse.error('Failed to add user to room', { status: 500 });
+    }
+  }
+  

--- a/src/app/api/rooms/route.js
+++ b/src/app/api/rooms/route.js
@@ -12,6 +12,47 @@ export const dynamic = "force-dynamic";
 /**
  * @swagger
  * /api/rooms:
+ *   post:
+ *     summary: Create a new room
+ *     description: Create a new room and add the user as a member
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *               user:
+ *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: string
+ *     responses:
+ *       200:
+ *         description: Successful response
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                 roomId:
+ *                   type: string
+ *       400:
+ *         description: Bad Request
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: Internal Server Error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error' 
  *   get:
  *     summary: Get room details
  *     description: Retrieve details for a specific room

--- a/src/app/api/rooms/route.js
+++ b/src/app/api/rooms/route.js
@@ -1,14 +1,113 @@
+import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
+import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
-import { v4 as uuidv4 } from "uuid";
+
 import prisma from "../../../../lib/db";
+import { checkMembership } from "../_utils";
+
+import { v4 as uuidv4 } from "uuid";
 
 export const dynamic = "force-dynamic";
+
+/**
+ * @swagger
+ * /api/rooms:
+ *   get:
+ *     summary: Get room details
+ *     description: Retrieve details for a specific room
+ *     parameters:
+ *       - in: query
+ *         name: roomId
+ *         schema:
+ *           type: string
+ *         required: true
+ *         description: The ID of the room
+ *     responses:
+ *       200:
+ *         description: Successful response
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Room'
+ *       400:
+ *         description: Bad Request
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: Internal Server Error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *
+ * components:
+ *  schemas:
+ *    Room:
+ *      type: object
+ *      properties:
+ *        id:
+ *          type: string
+ *        name:
+ *          type: string
+ *        metadata:
+ *          type: object
+ *        createdAt:
+ *          type: string
+ *        updatedAt:
+ *          type: string
+ *        deletedAt:
+ *          type: string
+ *        buildingId:
+ *          type: string
+ *        members:
+ *          type: array
+ *          items:
+ *            $ref: '#/components/schemas/RoomMember'
+ *    RoomMember:
+ *      type: object
+ *      properties:
+ *        id:
+ *          type: string
+ *        role:
+ *          type: string
+ *        firstName:
+ *          type: string
+ *        lastName:
+ *          type: string
+ *        metadata:
+ *          type: object
+ *        profileImage:
+ *          type: string
+ *        createdAt:
+ *          type: string
+ *        updatedAt:
+ *          type: string
+ *        deletedAt:
+ *          type: string
+ *        userId:
+ *          type: string
+ *    Error:
+ *      type: object
+ *      properties:
+ *         message:
+ *           type: string
+ */
+
 
 export async function POST(request, context) {
   const roomData = await request.json();
   const roomId = uuidv4();
   const shoppingListId = uuidv4();
   const choreListId = uuidv4();
+
+  if (!roomData.user.id) {
+    return NextResponse.json(
+      { message: "No user ID provided" },
+      { status: 400 }
+    );
+  }
 
   // Single transaction to create a room
   try {
@@ -71,7 +170,46 @@ export async function POST(request, context) {
       { status: 200 }
     );
   } catch (error) {
-    console.error('Error creating room:', error);
     return NextResponse.error('Failed to create room', { status: 500 });
   } 
+}
+
+export async function GET(request, context) {
+  try {
+    const roomId = request.nextUrl.searchParams.get("roomId");
+
+    if (!roomId) {
+      return NextResponse.json(
+        { message: "No room ID provided" },
+        { status: 400 }
+      );
+    }
+
+    const supabase = createServerComponentClient({ cookies });
+    const { data: user, error } = await supabase.auth.getUser();
+
+    if (error) {
+      return NextResponse.json({ message: "Unauthorized" }, { status: 400 });
+    }
+
+    await checkMembership(roomId, user.id);
+
+    const room = await prisma.room.findFirst({
+      where: {
+        id: roomId,
+      },
+      include: {
+        members: true,
+      },
+    });
+
+
+    return NextResponse.json({ ...room }, { status: 200 });
+  } catch (error) {
+    console.log("error getting room", error)
+    return NextResponse.json(
+      { message: "Error getting room", error: error },
+      { status: 500 }
+    );
+  }
 }

--- a/src/app/api/rooms/route.js
+++ b/src/app/api/rooms/route.js
@@ -9,7 +9,7 @@ import { v4 as uuidv4 } from "uuid";
 
 export const dynamic = "force-dynamic";
 
-/**
+/** 
  * @swagger
  * /api/rooms:
  *   post:


### PR DESCRIPTION
# Pull Request Template

## Description
Finalized the rooms API for now. I created a new API endpoint api/rooms/[slug] where the POST request is to add a room member and the DELETE request is to remove them. 

Users can now:
- add other users to a room
- remove other users from a room
- I also added to the API documentation. 
- I also fixed the rooms page to fetch and display all members. 
- I didn't create a DELETE request for the rooms. I think a single member shouldn't be able to delete a room (i.e. the way it is in telegram chats). Maybe we can delete the room after all members have left it. 

## Link to Ticket

Please indicate the ticket(s) in Notion that correspond to this PR.

- Ticket 1: https://www.notion.so/bathientran/17ada2fb913f478ea3d768fec00c92b5?v=05ae4b535dff4f0cb4ee5bf9cd18affb&p=20e94826d01249ae9fd31c6c340173cc&pm=s
- Ticket 2: https://www.notion.so/bathientran/17ada2fb913f478ea3d768fec00c92b5?v=05ae4b535dff4f0cb4ee5bf9cd18affb&p=52e5a715380f4cecbdcaacc3dfe0de04&pm=s
- [this is a duplicate ticket but I'm adding it here as well] https://www.notion.so/bathientran/17ada2fb913f478ea3d768fec00c92b5?v=05ae4b535dff4f0cb4ee5bf9cd18affb&p=1744e541ae734dc1ba355d73a3a0936e&pm=s

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## What Has Changed

Users can now:
- add other users to a room
- remove other users from a room
- I also added to the API documentation. 
- I also fixed the rooms page to fetch and display all members. 

## How Has This Been Tested / How Can This Be Tested

I tested it by making calls to the API and running the database locally. 
