### PR TITLE
hotfix(): previous commit broke the app

### DIFF
--- a/src/app/api/_utils.js
+++ b/src/app/api/_utils.js
@@ -16,12 +16,13 @@ export const getProfile = async () => {
           shoppingLists: { include: { shoppingListItems: true } },
         },
       },
-      buildings: {
-        include: {
-          members: true,
-          rooms: true,
-        },
-      },
+      // buildings: {
+      //   include: {
+      //     members: true,
+      //     rooms: true,
+      //   },
+      // },
+      // building
     },
   });
 


### PR DESCRIPTION
hotfix(): fixed an error introduced by this commit https://github.com/minerva-startup-spring2024/roommate-organizer/commit/6a7e3a147ca171e4f2527f2343d23364e9414c98. The app failed to run with this error: Cannot select both '$scalars: true' and a specific scalar field 'members'. ⨯ PrismaClientUnknownRequestError: Invalid `prisma.profile.findUnique()` invocation: Cannot select both '$scalars: true' and a specific scalar field 'members'. at async getProfile (./src/app/api/_utils.js:12:17). I think it's because the database schema hasn't been updated yet, we don't have a relation table between the buildings and members and we don't have a relationship defined between the buildings and rooms yet. For now I just commented out the lines causing the error


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

