### PR TITLE
UI changes in Room Preview

### DIFF
--- a/src/app/_components/AnnouncementsRoomPreviewSection/AnnouncementsRoomPreviewSection.js
+++ b/src/app/_components/AnnouncementsRoomPreviewSection/AnnouncementsRoomPreviewSection.js
@@ -1,8 +1,8 @@
 import styles from "./AnnouncementsRoomPreviewSection.module.css";
 
 function AnnouncementsRoomPreviewSection({ announcements }) {
-   // Get the latest 3 announcements
-   const sortedAnnouncements = announcements.sort((a, b) => {
+  // Get the latest 3 announcements
+  const sortedAnnouncements = announcements.sort((a, b) => {
     return new Date(b.updatedAt) - new Date(a.updatedAt);
   });
 
@@ -29,7 +29,7 @@ function AnnouncementsRoomPreviewSection({ announcements }) {
                   alt="Profile"
                 />
                 <div className={styles.subheader}>
-                  <p>Placeholder Name</p>
+                  <p>Name </p>
                   <p>Last Updated: {formattedUpdatedAt}</p>
                 </div>
               </div>
@@ -40,5 +40,5 @@ function AnnouncementsRoomPreviewSection({ announcements }) {
     </div>
   );
 }
-  
-  export default AnnouncementsRoomPreviewSection;
+
+export default AnnouncementsRoomPreviewSection;

--- a/src/app/_components/AnnouncementsRoomPreviewSection/AnnouncementsRoomPreviewSection.module.css
+++ b/src/app/_components/AnnouncementsRoomPreviewSection/AnnouncementsRoomPreviewSection.module.css
@@ -1,50 +1,61 @@
-  .announcementsSection {
-    margin-bottom: 20px;
-  }
-  
-  .announcementCards {
-    display: flex;
-    overflow-x: auto;
-  }
-  
-  .announcementCard {
-    background-color: rgba(145, 145, 145, 0.187);
-    border-radius: 10px;
-    padding: 10px;
-    margin-right: 10px;
-    display: flex;
-    flex-direction: column;
-  }
-  
-  .boxTitle {
-    font-size: 12px;
-    font-weight: 500;
-    margin-bottom: 6px;
-  }
+.announcementsSection {
+  margin-bottom: 10px;
+}
 
-  .subheader {
-    font-size: 14px;
-    font-weight: 300;
-    margin-bottom: 6px;
-  }
-  
-  .announcementCard p {
-    min-height: 40px;
-  }
+.announcementCards {
+  display: flex;
+  overflow-x: auto;
+}
 
-  .announcementContent {
-    margin-top: 10px;
-  }
+.announcementCard {
+  border-radius: 10px;
+  padding: 10px;
+  margin-right: 10px;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
 
-  .announcementDivider {
-    border-top: 1px solid #ccc;
-    margin-top: 6px;
-    margin-bottom: 4px;
-  }
-  
-  .profilePhoto {
-    width: 40px;
-    height: 40px;
-    border-radius: 22%;
-    margin-right: 10px; 
-  }
+.boxTitle {
+  font-size: 15px;
+  font-weight: 500;
+  margin-bottom: 6px;
+  padding: 10px;
+  background-color: rgba(192, 108, 132);
+  padding-top: 20px;
+  padding-left: 20px;
+}
+
+.subheader {
+  font-size: 14px;
+  font-weight: 300;
+  margin-bottom: 6px;
+  display: flex;
+}
+
+.announcementCard p {
+  min-height: 40px;
+}
+
+.announcementContent {
+  margin-top: 10px;
+}
+
+.announcementDivider {
+  border-top: 1px solid #ccc;
+  margin-top: 6px;
+  margin-bottom: 4px;
+}
+
+.profilePhoto {
+  width: 40px;
+  height: 40px;
+  border-radius: 22%;
+  margin-right: 10px;
+  display: none;
+}
+.announcementHeader {
+  display: flex;
+  align-items: center;
+  justify-content: start;
+}

--- a/src/app/_components/Room/Room.js
+++ b/src/app/_components/Room/Room.js
@@ -30,7 +30,7 @@
 //         title={roomDetails.name}
 //         details={true}
 //       />
-//       <div className={styles.mainContent}>  
+//       <div className={styles.mainContent}>
 //         {!loading && (
 //           <>
 //             {/* Announcements */}
@@ -61,7 +61,7 @@
 //         )}
 //       </div>
 //       {loading && (
-//         <div className={styles.loadingContainer}> 
+//         <div className={styles.loadingContainer}>
 //           <GreyBeatLoader />
 //         </div>
 //       )}
@@ -74,7 +74,7 @@
 import { useEffect, useState } from "react";
 import GreyBeatLoader from "../BeatLoaders/GreyBeatLoader";
 import RoomItemPreview from "../RoomItemPreview/RoomItemPreview";
-import AnnouncementsRoomPreviewSection from '../AnnouncementsRoomPreviewSection/AnnouncementsRoomPreviewSection';
+import AnnouncementsRoomPreviewSection from "../AnnouncementsRoomPreviewSection/AnnouncementsRoomPreviewSection";
 import styles from "./Room.module.css";
 export default function Room({ roomId }) {
   const [loading, setLoading] = useState(true);
@@ -100,28 +100,37 @@ export default function Room({ roomId }) {
       ) : (
         <>
           {/* Announcements */}
-          <AnnouncementsRoomPreviewSection announcements={roomDetails.announcements} />
+          <div className={`${styles.card} ${styles.announcementsCard}`}>
+            {" "}
+            <AnnouncementsRoomPreviewSection
+              announcements={roomDetails.announcements}
+            />
+          </div>
           {/* Chore and Shopping Previews */}
-          <RoomItemPreview
-            previewTitle="Chores"
-            items={
-              roomDetails.choreLists.length > 0
-                ? roomDetails.choreLists[0].choreListItems
-                : []
-            }
-            roomId={roomId}
-            linkRoute="chores"
-          />
-          <RoomItemPreview
-            previewTitle="Shopping Items"
-            items={
-              roomDetails.shoppingLists.length > 0
-                ? roomDetails.shoppingLists[0].shoppingListItems
-                : []
-            }
-            roomId={roomId}
-            linkRoute="shopping-list"
-          />
+          <div className={styles.listsCard}>
+            <RoomItemPreview
+              previewTitle="Chores"
+              items={
+                roomDetails.choreLists.length > 0
+                  ? roomDetails.choreLists[0].choreListItems
+                  : []
+              }
+              roomId={roomId}
+              linkRoute="chores"
+            />
+          </div>
+          <div className={styles.shoppinglistsCard}>
+            <RoomItemPreview
+              previewTitle="Shopping Items"
+              items={
+                roomDetails.shoppingLists.length > 0
+                  ? roomDetails.shoppingLists[0].shoppingListItems
+                  : []
+              }
+              roomId={roomId}
+              linkRoute="shopping-list"
+            />
+          </div>
         </>
       )}
     </div>

--- a/src/app/_components/Room/Room.module.css
+++ b/src/app/_components/Room/Room.module.css
@@ -1,23 +1,22 @@
 .container {
-    padding: 24px 36px;
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    justify-content: center;
-    height: 100%; 
-    overflow: scroll;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  height: 100%;
+  overflow: scroll;
 }
 
 .previewsSection {
-    display: flex;
-    width: 100%; 
+  display: flex;
+  width: 100%;
 }
 
 .previewsSection > * {
-    flex: 1;
-    margin-right: 10px;
+  flex: 1;
+  margin-right: 10px;
 }
 
 .previewsSection > *:last-child {
-    margin-right: 0; /* Remove margin from the last preview item */
+  margin-right: 0; /* Remove margin from the last preview item */
 }

--- a/src/app/_components/Room/Room.module.css
+++ b/src/app/_components/Room/Room.module.css
@@ -1,10 +1,15 @@
 .container {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: stretch;
   justify-content: center;
   height: 100%;
-  overflow: scroll;
+  overflow: auto;
+  padding-bottom: 0px;
+  background-color: #f4dae2;
+  padding-top: 0px;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .previewsSection {
@@ -19,4 +24,24 @@
 
 .previewsSection > *:last-child {
   margin-right: 0; /* Remove margin from the last preview item */
+}
+.listsCard {
+  background-color: rgba(192, 108, 132);
+  padding-left: 20px;
+  padding-right: 20px;
+  padding-top: 15px;
+  border: 1px solid black;
+  border-radius: 2%;
+  margin: 4px;
+}
+.shoppinglistsCard {
+  background-color: rgba(192, 108, 132);
+  padding-left: 20px;
+  padding-right: 20px;
+  padding-top: 15px;
+  padding-bottom: 20px;
+  border: 1px solid black;
+  border-radius: 2%;
+  margin: 4px;
+  margin-top: 0px;
 }

--- a/src/app/_components/RoomItemPreview/RoomItemPreview.js
+++ b/src/app/_components/RoomItemPreview/RoomItemPreview.js
@@ -12,7 +12,7 @@ const RoomItemPreview = ({ previewTitle, items, roomId, linkRoute }) => {
           <div className={styles.emptyText}>No {previewTitle}</div>
         ) : (
           <>
-            {items.slice(0, 3).map((item) => (
+            {items.slice(0, 1).map((item) => (
               <Link
                 href={`${roomId}/${linkRoute}`}
                 key={item.id}

--- a/src/app/_components/RoomItemPreview/RoomItemPreview.module.css
+++ b/src/app/_components/RoomItemPreview/RoomItemPreview.module.css
@@ -1,4 +1,3 @@
-
 .itemPreviewContainer {
   width: 100%;
   margin-bottom: 30px;
@@ -10,6 +9,7 @@
   width: 100%;
   height: 100%;
   box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.02);
+  background-color: #f4dae2;
 }
 
 .itemLabel {
@@ -24,10 +24,11 @@
 }
 
 .boxTitle {
-  font-size: 12px;
+  font-size: 15px;
   font-weight: 500;
   margin-bottom: 6px;
   text-transform: uppercase;
+  padding: 5px;
 }
 
 .itemContainer {
@@ -57,6 +58,11 @@
   border: 1px solid var(--color-black-base);
   cursor: pointer;
   width: 100%;
+  background: linear-gradient(
+    to right,
+    rgba(221, 94, 137, 1) 0%,
+    rgba(247, 187, 151, 1) 100%
+  );
 }
 
 .emptyText {

--- a/src/app/_components/TopBar/TopBar.js
+++ b/src/app/_components/TopBar/TopBar.js
@@ -1,8 +1,8 @@
-import { FaHome } from "react-icons/fa";
+import { FaHome, FaSignOutAlt } from "react-icons/fa";
 import { FaGear } from "react-icons/fa6";
 import styles from "./TopBar.module.css";
 
-export default function TopBar({ title, details, onDetailsClick }) {
+export default function TopBar({ title, details, onDetailsClick, onLogout }) {
   return (
     <div className={styles.topBar}>
       <div className={styles.headerContainer}>
@@ -13,10 +13,12 @@ export default function TopBar({ title, details, onDetailsClick }) {
               <p className={styles.header}>{title}</p>
             </div>
             <FaGear size={22} color={"white"} />
+            <FaSignOutAlt size={22} color={"white"} onClick={onLogout} />
           </>
         ) : (
           <>
             <p className={styles.header}>{title}</p>
+            <FaSignOutAlt size={22} color={"white"} onClick={onLogout} />
           </>
         )}
       </div>

--- a/src/app/_components/TopBar/TopBar.module.css
+++ b/src/app/_components/TopBar/TopBar.module.css
@@ -1,33 +1,37 @@
 .container {
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-    height: 100%;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
 }
 
 .topBar {
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-end;
-    padding: 12px 36px;
-    height: 100px;
-    background: linear-gradient(to right, rgba(221, 94, 137, 1) 0%, rgba(247, 187, 151, 1) 100%);
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  padding: 12px 36px;
+  height: 50px;
+  background: linear-gradient(
+    to right,
+    rgba(221, 94, 137, 1) 0%,
+    rgba(247, 187, 151, 1) 100%
+  );
 }
 
 .headerContainer {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .header {
-    font-size: 18px;
-    font-weight: 600;
-    color: white;
+  font-size: 18px;
+  font-weight: 600;
+  color: white;
 }
 
 .roomTitle {
-    display: flex;
-    flex-direction: row;
+  display: flex;
+  flex-direction: row;
 }

--- a/src/app/app/layout.module.css
+++ b/src/app/app/layout.module.css
@@ -1,12 +1,12 @@
 .navContainer {
-    position: absolute;
-    display: flex;
-    justify-content: space-between;
-    padding: 0 36px;
-    padding-top: 12px;
-    border-top: 1px solid #00000010;
-    width: 100%;
-    left: 0;
-    bottom: 0;
-    height: 60px;
+  position: absolute;
+  display: flex;
+  justify-content: space-between;
+  padding: 0 36px;
+  padding-top: 12px;
+  border-top: 1px solid #00000010;
+  width: 100%;
+  left: 0;
+  bottom: 0;
+  height: 60px;
 }

--- a/src/app/app/page.js
+++ b/src/app/app/page.js
@@ -3,13 +3,20 @@ import RoomsOverview from "@/app/_components/RoomsOverview.js";
 import TopBar from "@/app/_components/TopBar/TopBar.js";
 import { getProfile } from "@/app/api/_utils";
 import "@/app/globals.css";
+import { redirect } from "next/navigation";
 
 export default async function HomePage() {
   const user = await getProfile();
-
+  if (!user) {
+    redirect("/");
+  }
+  const handleLogout = async () => {
+    await fetch("/api/logout", { method: "POST" });
+    redirect("/"); // Redirect to login after calling logout endpoint
+  };
   return (
     <div>
-      <TopBar title={"Rooms"} />
+      <TopBar title={"Rooms"} onLogout={handleLogout} />
       <div className="mainContainer">
         <RoomsOverview rooms={user.rooms} />
         <CreateRoomBox context={{ user: user }} />

--- a/src/app/app/rooms/[slug]/layout.module.css
+++ b/src/app/app/rooms/[slug]/layout.module.css
@@ -1,9 +1,8 @@
 .container {
-    padding: 24px 36px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    height: 100%;
-    overflow: scroll;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  overflow: scroll;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,7 +2,7 @@
   --max-width: 1100px;
   --border-radius: 12px;
 
-  font-family: "Inter", sans-serif; 
+  font-family: "Inter", sans-serif;
 
   --foreground-rgb: 0, 0, 0;
 
@@ -36,15 +36,15 @@
   --card-rgb: 180, 185, 188;
   --card-border-rgb: 131, 134, 135;
 
-  --color-grey-100: #DDDCE1;
-  --color-grey-300: #6F727D;
+  --color-grey-100: #dddce1;
+  --color-grey-300: #6f727d;
   --color-grey-700: #373943;
-  --color-pink-accent: #DD5E89;
-  --color-pink-action: #F26C6D;
-  --color-pink-background: #EDD4D4;
-  --color-white-base: #FFFFFF;
+  --color-pink-accent: #dd5e89;
+  --color-pink-action: #f26c6d;
+  --color-pink-background: #edd4d4;
+  --color-white-base: #ffffff;
   --color-black-base: #000000;
-  --color-green: #00972A;
+  --color-green: #00972a;
 }
 
 * {
@@ -60,9 +60,8 @@ body {
 }
 
 body {
-  
   color: rgb(var(--foreground-rgb));
-  background: white
+  background: white;
 }
 
 a {

--- a/src/app/login/actions.js
+++ b/src/app/login/actions.js
@@ -27,5 +27,5 @@ export async function login(formData) {
     return error.message;
   }
 
-  redirect("/");
+  redirect("/apps/rooms");
 }

--- a/src/app/login/page.js
+++ b/src/app/login/page.js
@@ -40,7 +40,7 @@ export default function LoginPage() {
               }
               required
             />
-            {/* Add an icon inside the input or as a sibling element */}
+            {}
           </div>
           <div className="inputContainer">
             <input
@@ -55,7 +55,7 @@ export default function LoginPage() {
               }
               required
             />
-            {/* Add an icon inside the input or as a sibling element */}
+            {}
           </div>
           <div>{error}</div>
           <button type="submit" className="signUpButton">

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -6,7 +6,7 @@ import "./globals.css";
 export default async function LandingPage() {
   const user = await getProfile();
   if (user) {
-    redirect("/app");
+    redirect("/app/rooms");
   }
 
   return (


### PR DESCRIPTION
# Pull Request Template

## Description

Change in the styling of the Room preview page.
Only displays one item from each list to avoid overlapping text.
<img width="494" alt="image" src="https://github.com/minerva-startup-spring2024/roommate-organizer/assets/77775666/434340e5-d87e-4ef3-aba6-58e2a738b8d2">

## Link to Ticket

Please indicate the ticket(s) in Notion that correspond to this PR.

- [Ticket 1](https://www.notion.so/bathientran/Styling-the-Room-preview-page-b486b14c0f6d49e597e521f75e2dce8a?pvs=4)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## What Has Changed

Please describe in bullets what you have changed.

- The UI has changed from before.
- The cards display only one item in preview mode to prevent overlapping of texts.

## How Has This Been Tested / How Can This Be Tested

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- Go to either of the lists and add as many items as you can. Only one should display in the preview.
